### PR TITLE
refactor(skills): convert bmad-help task to native skill directory

### DIFF
--- a/src/bmm/workflows/1-analysis/create-product-brief/steps/step-06-complete.md
+++ b/src/bmm/workflows/1-analysis/create-product-brief/steps/step-06-complete.md
@@ -128,7 +128,7 @@ Recap that the brief captures everything needed to guide subsequent product deve
 
 ### 5. Suggest next steps
 
-Product Brief complete. Read fully and follow: `{project-root}/_bmad/core/tasks/help.md`
+Product Brief complete. Read fully and follow: `bmad-help` skill
 
 ---
 

--- a/src/bmm/workflows/2-plan-workflows/create-prd/steps-c/step-12-complete.md
+++ b/src/bmm/workflows/2-plan-workflows/create-prd/steps-c/step-12-complete.md
@@ -87,7 +87,7 @@ Offer validation workflows to ensure PRD is ready for implementation:
 
 ### 4. Suggest Next Workflows
 
-PRD complete. Read fully and follow: `{project-root}/_bmad/core/tasks/help.md`
+PRD complete. Read fully and follow: `bmad-help` skill
 
 ### 5. Final Completion Confirmation
 

--- a/src/bmm/workflows/2-plan-workflows/create-prd/steps-v/step-v-13-report-complete.md
+++ b/src/bmm/workflows/2-plan-workflows/create-prd/steps-v/step-v-13-report-complete.md
@@ -197,7 +197,7 @@ Display:
 - **IF X (Exit):**
   - Display: "**Validation Report Saved:** {validationReportPath}"
   - Display: "**Summary:** {overall status} - {recommendation}"
-  - PRD Validation complete. Read fully and follow: `{project-root}/_bmad/core/tasks/help.md`
+  - PRD Validation complete. Read fully and follow: `bmad-help` skill
 
 - **IF Any other:** Help user, then redisplay menu
 

--- a/src/bmm/workflows/2-plan-workflows/create-ux-design/steps/step-14-complete.md
+++ b/src/bmm/workflows/2-plan-workflows/create-ux-design/steps/step-14-complete.md
@@ -82,7 +82,7 @@ Update the main workflow status file:
 
 ### 3. Suggest Next Steps
 
-UX Design complete. Read fully and follow: `{project-root}/_bmad/core/tasks/help.md`
+UX Design complete. Read fully and follow: `bmad-help` skill
 
 ### 5. Final Completion Confirmation
 

--- a/src/bmm/workflows/3-solutioning/check-implementation-readiness/steps/step-06-final-assessment.md
+++ b/src/bmm/workflows/3-solutioning/check-implementation-readiness/steps/step-06-final-assessment.md
@@ -109,7 +109,7 @@ The assessment found [number] issues requiring attention. Review the detailed re
 
 The implementation readiness workflow is now complete. The report contains all findings and recommendations for the user to consider.
 
-Implementation Readiness complete. Read fully and follow: `{project-root}/_bmad/core/tasks/help.md`
+Implementation Readiness complete. Read fully and follow: `bmad-help` skill
 
 ---
 

--- a/src/bmm/workflows/3-solutioning/create-architecture/steps/step-08-complete.md
+++ b/src/bmm/workflows/3-solutioning/create-architecture/steps/step-08-complete.md
@@ -41,7 +41,7 @@ completedAt: '{{current_date}}'
 
 ### 3. Next Steps Guidance
 
-Architecture complete. Read fully and follow: `{project-root}/_bmad/core/tasks/help.md`
+Architecture complete. Read fully and follow: `bmad-help` skill
 
 Upon Completion of task output: offer to answer any questions about the Architecture Document.
 

--- a/src/bmm/workflows/3-solutioning/create-epics-and-stories/steps/step-04-final-validation.md
+++ b/src/bmm/workflows/3-solutioning/create-epics-and-stories/steps/step-04-final-validation.md
@@ -144,6 +144,6 @@ If all validations pass:
 
 When C is selected, the workflow is complete and the epics.md is ready for development.
 
-Epics and Stories complete. Read fully and follow: `{project-root}/_bmad/core/tasks/help.md`
+Epics and Stories complete. Read fully and follow: `bmad-help` skill
 
 Upon Completion of task output: offer to answer any questions about the Epics and Stories.

--- a/src/core/module-help.csv
+++ b/src/core/module-help.csv
@@ -1,7 +1,7 @@
 module,phase,name,code,sequence,workflow-file,command,required,agent,options,description,output-location,outputs
 core,anytime,Brainstorming,BSP,,_bmad/core/workflows/brainstorming/workflow.md,bmad-brainstorming,false,analyst,,"Generate diverse ideas through interactive techniques. Use early in ideation phase or when stuck generating ideas.",{output_folder}/brainstorming/brainstorming-session-{{date}}.md,,
 core,anytime,Party Mode,PM,,_bmad/core/workflows/party-mode/workflow.md,bmad-party-mode,false,party-mode facilitator,,"Orchestrate multi-agent discussions. Use when you need multiple agent perspectives or want agents to collaborate.",,
-core,anytime,bmad-help,BH,,_bmad/core/tasks/help.md,bmad-help,false,,,"Get unstuck by showing what workflow steps come next or answering BMad Method questions.",,
+core,anytime,bmad-help,BH,,skill:bmad-help,bmad-help,false,,,"Get unstuck by showing what workflow steps come next or answering BMad Method questions.",,
 core,anytime,Index Docs,ID,,_bmad/core/tasks/index-docs.xml,bmad-index-docs,false,,,"Create lightweight index for quick LLM scanning. Use when LLM needs to understand available docs without loading everything.",,
 core,anytime,Shard Document,SD,,_bmad/core/tasks/shard-doc.xml,bmad-shard-doc,false,,,"Split large documents into smaller files by sections. Use when doc becomes too large (>500 lines) to manage effectively.",,
 core,anytime,Editorial Review - Prose,EP,,_bmad/core/tasks/editorial-review-prose.xml,bmad-editorial-review-prose,false,,,"Review prose for clarity, tone, and communication issues. Use after drafting to polish written content.",report located with target document,"three-column markdown table with suggested fixes",

--- a/src/core/tasks/bmad-help/SKILL.md
+++ b/src/core/tasks/bmad-help/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: bmad-help
+description: 'Analyzes what is done and the users query and offers advice on what to do next. Use if user says what should I do next or what do I do now'
+---
+
+Follow the instructions in [workflow.md](workflow.md).

--- a/src/core/tasks/bmad-help/bmad-skill-manifest.yaml
+++ b/src/core/tasks/bmad-help/bmad-skill-manifest.yaml
@@ -1,0 +1,1 @@
+type: skill

--- a/src/core/tasks/bmad-help/workflow.md
+++ b/src/core/tasks/bmad-help/workflow.md
@@ -1,8 +1,3 @@
----
-name: help
-description: 'Analyzes what is done and the users query and offers advice on what to do next. Use if user says what should I do next or what do I do now'
----
-
 # Task: BMAD Help
 
 ## ROUTING RULES

--- a/src/core/tasks/bmad-skill-manifest.yaml
+++ b/src/core/tasks/bmad-skill-manifest.yaml
@@ -8,9 +8,9 @@ editorial-review-structure.xml:
   type: task
   description: "Structural editor that proposes cuts, reorganization, and simplification while preserving comprehension"
 
-help.md:
+bmad-help:
   canonicalId: bmad-help
-  type: task
+  type: skill
   description: "Analyzes what is done and the users query and offers advice on what to do next"
 
 index-docs.xml:


### PR DESCRIPTION
## Summary

Converts `src/core/tasks/help.md` into a native skill directory at `src/core/tasks/bmad-help/`, following the same pattern as the adversarial review skill conversion.

## Changes

- **New skill directory** `src/core/tasks/bmad-help/` with:
  - `SKILL.md` — frontmatter (name + description) + link to workflow.md
  - `workflow.md` — full task content (renamed from help.md)
  - `bmad-skill-manifest.yaml` — `type: skill`
- **`src/core/tasks/bmad-skill-manifest.yaml`** — updated entry key from `help.md` to `bmad-help`, type from `task` to `skill`
- **`src/core/module-help.csv`** — workflow-file changed from `_bmad/core/tasks/help.md` to `skill:bmad-help`
- **7 workflow step files** — replaced bare `{project-root}/_bmad/core/tasks/help.md` path references with `bmad-help` skill invocation

## What Does NOT Change

- Task behavior, routing rules, display rules, or execution logic
- CHANGELOG entries